### PR TITLE
feat: MMG-25 모임 단건 조회 api 생성

### DIFF
--- a/src/main/java/com/moiming/core/BaseControllerAdvice.java
+++ b/src/main/java/com/moiming/core/BaseControllerAdvice.java
@@ -1,5 +1,8 @@
 package com.moiming.core;
 
+import com.moiming.core.exception.CustomNoResultException;
+import com.moiming.core.exception.MoimingException;
+import jakarta.persistence.NoResultException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -12,6 +15,21 @@ import java.util.stream.Collectors;
 
 @ControllerAdvice
 public class BaseControllerAdvice {
+
+    @ExceptionHandler(MoimingException.class)
+    public ResponseEntity<String> moimingExceptionHandler(MoimingException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> exceptionHandler(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(e.getMessage());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<List<InvalidResponse>> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
         BindingResult bindingResult = e.getBindingResult();
@@ -23,5 +41,12 @@ public class BaseControllerAdvice {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(responses);
+    }
+
+    @ExceptionHandler(CustomNoResultException.class)
+    public ResponseEntity<String> noResultExceptionExceptionHandler(CustomNoResultException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(e.getMessage());
     }
 }

--- a/src/main/java/com/moiming/core/BaseControllerAdvice.java
+++ b/src/main/java/com/moiming/core/BaseControllerAdvice.java
@@ -1,8 +1,6 @@
 package com.moiming.core;
 
 import com.moiming.core.exception.CustomNoResultException;
-import com.moiming.core.exception.MoimingException;
-import jakarta.persistence.NoResultException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -15,13 +13,6 @@ import java.util.stream.Collectors;
 
 @ControllerAdvice
 public class BaseControllerAdvice {
-
-    @ExceptionHandler(MoimingException.class)
-    public ResponseEntity<String> moimingExceptionHandler(MoimingException e) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(e.getMessage());
-    }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> exceptionHandler(Exception e) {

--- a/src/main/java/com/moiming/core/exception/CustomNoResultException.java
+++ b/src/main/java/com/moiming/core/exception/CustomNoResultException.java
@@ -1,0 +1,13 @@
+package com.moiming.core.exception;
+
+import jakarta.persistence.NoResultException;
+
+public class CustomNoResultException extends NoResultException {
+    public CustomNoResultException() {
+        super("조회된 데이터가 없습니다.");
+    }
+
+    public CustomNoResultException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/moiming/core/exception/MoimingException.java
+++ b/src/main/java/com/moiming/core/exception/MoimingException.java
@@ -1,0 +1,11 @@
+package com.moiming.core.exception;
+
+public class MoimingException extends RuntimeException {
+    public MoimingException() {
+        super("예기치 못한 오류가 발생하였습니다.");
+    }
+
+    public MoimingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/moiming/meet/application/MeetInfoService.java
+++ b/src/main/java/com/moiming/meet/application/MeetInfoService.java
@@ -1,15 +1,28 @@
 package com.moiming.meet.application;
 
+import com.moiming.core.exception.CustomNoResultException;
 import com.moiming.meet.domain.MeetInfo;
+import com.moiming.meet.dto.MeetInfoResponse;
 import com.moiming.meet.infra.MeetInfoRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MeetInfoService {
     private final MeetInfoRepository repository;
+
+    /**
+     * 특정 모임을 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public MeetInfoResponse findMeet(Long meetId) {
+        MeetInfo meetInfo = repository.findById(meetId)
+            .orElseThrow(CustomNoResultException::new);
+
+        return MeetInfoResponse.fromEntity(meetInfo);
+    }
 
     /**
      * 모임을 생성합니다.

--- a/src/main/java/com/moiming/meet/domain/MeetInfo.java
+++ b/src/main/java/com/moiming/meet/domain/MeetInfo.java
@@ -7,6 +7,9 @@ import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.hibernate.annotations.Comment;
 
+import java.time.LocalDate;
+import java.util.Objects;
+
 @Entity
 @Getter
 @Builder
@@ -29,4 +32,21 @@ public class MeetInfo extends BaseEntity {
     @Comment("모임 설명")
     @Column(name = "DESCRIPTION")
     private String description;
+
+    @Comment("모임 생성일")
+    @Column(name = "CREATE_DATE")
+    private LocalDate createDate;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MeetInfo meetInfo = (MeetInfo) o;
+        return Objects.equals(meetSeq, meetInfo.meetSeq) && Objects.equals(name, meetInfo.name) && Objects.equals(description, meetInfo.description) && Objects.equals(createDate, meetInfo.createDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(meetSeq, name, description, createDate);
+    }
 }

--- a/src/main/java/com/moiming/meet/dto/MeetCreateRequest.java
+++ b/src/main/java/com/moiming/meet/dto/MeetCreateRequest.java
@@ -4,7 +4,10 @@ import com.moiming.meet.domain.MeetInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
 
 import static com.moiming.meet.dto.MeetValidateMessage.NAME_IS_NOT_NULL;
 import static com.moiming.meet.dto.MeetValidateMessage.NAME_SIZE_INVALID;
@@ -27,6 +30,7 @@ public class MeetCreateRequest {
         return MeetInfo.builder()
                 .name(this.name)
                 .description(this.description)
+                .createDate(LocalDate.now())
                 .build();
     }
 }

--- a/src/main/java/com/moiming/meet/dto/MeetInfoResponse.java
+++ b/src/main/java/com/moiming/meet/dto/MeetInfoResponse.java
@@ -1,0 +1,37 @@
+package com.moiming.meet.dto;
+
+import com.moiming.meet.domain.MeetInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "모임 단건 조회 응답 DTO")
+public class MeetInfoResponse {
+    @Schema(description = "모임 ID", example = "1")
+    private Long meetId;
+
+    @Schema(description = "모임명", example = "moiming 관리자 모임")
+    private String name;
+
+    @Schema(description = "모임 설명", example = "moiming 개발자 모임을 위한 모임입니다.")
+    private String description;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @Schema(description = "모임 생성일", example = "2023-08-23")
+    private LocalDate createDate;
+
+    public static MeetInfoResponse fromEntity(MeetInfo meetInfo) {
+        return MeetInfoResponse.builder()
+                .meetId(meetInfo.getMeetSeq())
+                .name(meetInfo.getName())
+                .description(meetInfo.getDescription())
+                .createDate(meetInfo.getCreateDate())
+                .build();
+    }
+}

--- a/src/main/java/com/moiming/meet/web/MeetsController.java
+++ b/src/main/java/com/moiming/meet/web/MeetsController.java
@@ -2,11 +2,10 @@ package com.moiming.meet.web;
 
 import com.moiming.meet.application.MeetInfoService;
 import com.moiming.meet.dto.MeetCreateRequest;
-import com.moiming.meet.domain.MeetInfo;
+import com.moiming.meet.dto.MeetInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,8 +27,8 @@ public class MeetsController {
 
     @GetMapping("/{meetSeq}")
     @Operation(summary = "모임 상세 조회", description = "특정 모임을 상세 조회합니다.")
-    public void meetSelect(@PathParam("meetSeq") Long meetSeq) {
-        //TODO: meetSeq에 대한 모임 상세 정보를 조회합니다.
+    public MeetInfoResponse meetSelect(@PathVariable("meetSeq") Long meetSeq) {
+        return meetInfoService.findMeet(meetSeq);
     }
 
     @PostMapping

--- a/src/test/java/com/moiming/meet/infra/MeetInfoRepositoryTest.java
+++ b/src/test/java/com/moiming/meet/infra/MeetInfoRepositoryTest.java
@@ -8,13 +8,35 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.LocalDate;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
 class MeetInfoRepositoryTest {
+
     @Autowired
     private MeetInfoRepository repository;
+
+    @Test
+    @DisplayName("모임 조회 성공")
+    void find() {
+        //given
+        MeetInfo meetInfo = 모임_저장_성공(MeetInfo.builder()
+                .name("name")
+                .description("description")
+                .createDate(LocalDate.now())
+                .build());
+
+        Long meetId = meetInfo.getMeetSeq();
+
+        //when
+        MeetInfo response = repository.findById(meetId).get();
+
+        //then
+        assertThat(meetInfo).isEqualTo(response);
+    }
 
     @Test
     @DisplayName("모임 저장 성공")
@@ -23,12 +45,17 @@ class MeetInfoRepositoryTest {
         MeetInfo meetInfo = MeetInfo.builder()
                 .name("name")
                 .description("description")
+                .createDate(LocalDate.now())
                 .build();
 
         //when
-        MeetInfo result = repository.save(meetInfo);
+        MeetInfo result = 모임_저장_성공(meetInfo);
 
         //then
         assertThat(meetInfo).isEqualTo(result);
+    }
+
+    private MeetInfo 모임_저장_성공(MeetInfo meetInfo) {
+        return repository.save(meetInfo);
     }
 }

--- a/src/test/java/com/moiming/meet/web/MeetsControllerTest.java
+++ b/src/test/java/com/moiming/meet/web/MeetsControllerTest.java
@@ -1,9 +1,11 @@
 package com.moiming.meet.web;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moiming.meet.dto.MeetCreateRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -49,41 +52,86 @@ class MeetsControllerTest {
                 .build();
     }
 
-    @Test
+    @Nested
+    @DisplayName("모임 단건 조회")
+    class findMeet {
+        @Test
+        @DisplayName("모임 단건 조회 성공")
+        void findMeetSuccess() throws Exception {
+            //given
+            String param = 모임_생성_파라미터();
+
+            //when
+            MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.post(baseUrl)
+                            .content(param)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isCreated())
+                    .andReturn();
+
+            mockMvc.perform(MockMvcRequestBuilders.get(mvcResult.getResponse().getRedirectedUrl()))
+                    .andExpect(MockMvcResultMatchers.status().isOk());
+        }
+
+        @Test
+        @DisplayName("모임 단건 조회 실패")
+        void findMeetFailed() throws Exception {
+            //given
+            Long meetId = 99999L;
+
+            //when & then
+            mockMvc.perform(MockMvcRequestBuilders.get(baseUrl + "/{meetId}", meetId)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isNotFound());
+        }
+    }
+
+    @Nested
     @DisplayName("모임 저장")
-    void meetCreate() throws Exception {
-        //given
+    class meetCreate {
+        @Test
+        @DisplayName("모임 저장 성공")
+        void meetCreateSuccess() throws Exception {
+            //given
+            String param = 모임_생성_파라미터();
+
+            //when & then
+            mockMvc.perform(MockMvcRequestBuilders.post(baseUrl)
+                            .content(param)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isCreated());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = "사랑과 아침이 말 이웃 이런 나는 다 때 까닭입니다. 이름을 가득 나의 라이너 하나에 이름을 밤이 묻힌 거외다. 이국 같이 너무나 봅니다.")
+        @NullAndEmptySource
+        @DisplayName("모임 저장시 잘못된 모임 값 입력으로 인한 BAD REQUEST 응답")
+        void meetCreateBadRequest(String name) throws Exception {
+            //given
+            final MeetCreateRequest request = MeetCreateRequest.builder()
+                    .name(name)
+                    .description("description")
+                    .build();
+
+            String param = objectMapper.writeValueAsString(request);
+
+            //when & then
+            mockMvc.perform(MockMvcRequestBuilders.post(baseUrl)
+                            .content(param)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+    }
+
+    private String 모임_생성_파라미터() throws JsonProcessingException {
         final MeetCreateRequest request = MeetCreateRequest.builder()
                 .name("name")
                 .description("description")
                 .build();
 
-        String param = objectMapper.writeValueAsString(request);
-
-        //when & then
-        mockMvc.perform(MockMvcRequestBuilders.post(baseUrl)
-                        .content(param)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isCreated());
+        return objectMapper.writeValueAsString(request);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = "사랑과 아침이 말 이웃 이런 나는 다 때 까닭입니다. 이름을 가득 나의 라이너 하나에 이름을 밤이 묻힌 거외다. 이국 같이 너무나 봅니다.")
-    @NullAndEmptySource
-    @DisplayName("모임 저장시 잘못된 모임 값 입력으로 인한 BAD REQUEST 응답")
-    void meetCreateBadRequest(String name) throws Exception {
-        //given
-        final MeetCreateRequest request = MeetCreateRequest.builder()
-                .name(name)
-                .description("description")
-                .build();
-
-        String param = objectMapper.writeValueAsString(request);
-
-        //when & then
-        mockMvc.perform(MockMvcRequestBuilders.post(baseUrl)
-                        .content(param)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    private <T> T 응답값을_객체에_매핑함(MvcResult mvcResult, Class<T> type) throws Exception {
+        return objectMapper.readValue(mvcResult.getResponse().getContentAsString(), type);
     }
 }

--- a/src/test/java/com/moiming/meet/web/MeetsControllerTest.java
+++ b/src/test/java/com/moiming/meet/web/MeetsControllerTest.java
@@ -61,13 +61,13 @@ class MeetsControllerTest {
             //given
             String param = 모임_생성_파라미터();
 
-            //when
             MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.post(baseUrl)
                             .content(param)
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(MockMvcResultMatchers.status().isCreated())
                     .andReturn();
 
+            //when
             mockMvc.perform(MockMvcRequestBuilders.get(mvcResult.getResponse().getRedirectedUrl()))
                     .andExpect(MockMvcResultMatchers.status().isOk());
         }


### PR DESCRIPTION
## 💁🏻‍♀️ 개요
모임 단건 조회를 위한 API를 개발하였습니다.

---
## 📝 작업 내용
- 1. 응답 DTO부터 각 계층에 코드를 작성하였습니다.
- 2. 각 계층의 테스트 코드 작성하였습니다.
- 3. ControllerAdvice에 Handler할 Exception을 몇가지 더 추가 하였습니다.

---
## 📍 주요 내용
- 